### PR TITLE
Select current tab when open picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Options can be set by calling the setup function. The following things can be ch
 ### entry_formatter
 This changes how a tab is represented in the picker. By default the following function is used:
 ```lua
-entry_formatter = function(tab_id, buffer_ids, file_names, file_paths)
+entry_formatter = function(tab_id, buffer_ids, file_names, file_paths, is_current)
 	local entry_string = table.concat(file_names, ', ')
 	return string.format('%d: %s', tab_id, entry_string)
 end,
@@ -58,7 +58,7 @@ To alter this behaviour, just assign your own function.
 ### entry_ordinal
 This changes how tabs are sorted in the picker. The ordinal is also used to determine which entries match a given search query. The following function is used by default:
 ```lua
-entry_ordinal = function(tab_id, buffer_ids, file_names, file_paths)
+entry_ordinal = function(tab_id, buffer_ids, file_names, file_paths, is_current)
 	return table.concat(file_names, ' ')
 end,
 ```

--- a/doc/telescope-tabs.txt
+++ b/doc/telescope-tabs.txt
@@ -33,10 +33,12 @@ require'telescope-tabs'.setup {
     --             tab.
     -- file_paths: A list of paths (strings) for every buffer opened in the
     --             tab.
+    -- is_current: Boolean value, true if it is the current tab.
+    --
     -- buffer_ids, file_names and file_paths contain their information in
     -- the same order. So buffer_ids[1], file_names[1] and file_paths[1]
     -- refer to the same buffer.
-    entry_formatter = function(tab_id, buffer_ids, file_names, file_paths)
+    entry_formatter = function(tab_id, buffer_ids, file_names, file_paths, is_current)
         local entry_string = table.concat(file_names, ', ')
         return string.format('%d: %s', tab_id, entry_string)
     end,
@@ -53,10 +55,12 @@ require'telescope-tabs'.setup {
     --             tab.
     -- file_paths: A list of paths (strings) for every buffer opened in the
     --             tab.
+    -- is_current: Boolean value, true if it is the current tab.
+    --
     -- buffer_ids, file_names and file_paths contain their information in
     -- the same order. So buffer_ids[1], file_names[1] and file_paths[1]
     -- refer to the same buffer.
-    entry_ordinal = function(tab_id, buffer_ids, file_names, file_paths)
+    entry_ordinal = function(tab_id, buffer_ids, file_names, file_paths, is_current)
         return table.concat(file_names, ' ')
     end,
 

--- a/lua/telescope/_extensions/telescope-tabs/main.lua
+++ b/lua/telescope/_extensions/telescope-tabs/main.lua
@@ -83,11 +83,13 @@ end
 M.list_tabs = function(opts)
 	opts = vim.tbl_deep_extend('force', M.conf, opts or {})
 	local res = {}
-	for _, tid in ipairs(vim.api.nvim_list_tabpages()) do
+	local current_tab = { number = vim.api.nvim_tabpage_get_number(0), index = nil }
+	for index, tid in ipairs(vim.api.nvim_list_tabpages()) do
 		local file_names = {}
 		local file_paths = {}
 		local file_ids = {}
 		local window_ids = {}
+		local is_current = current_tab.number == vim.api.nvim_tabpage_get_number(tid)
 		for _, wid in ipairs(vim.api.nvim_tabpage_list_wins(tid)) do
 			local bid = vim.api.nvim_win_get_buf(wid)
 			local path = vim.api.nvim_buf_get_name(bid)
@@ -96,6 +98,9 @@ M.list_tabs = function(opts)
 			table.insert(file_paths, path)
 			table.insert(file_ids, bid)
 			table.insert(window_ids, wid)
+		end
+		if is_current then
+			current_tab.index = index
 		end
 		table.insert(res, { file_names, file_paths, file_ids, window_ids, tid })
 	end
@@ -131,6 +136,11 @@ M.list_tabs = function(opts)
 				return true
 			end,
 			previewer = opts.show_preview and conf.file_previewer {} or nil,
+			on_complete = {
+				function(picker)
+					picker:set_selection(current_tab.index - 1)
+				end,
+			},
 		})
 		:find()
 end

--- a/lua/telescope/_extensions/telescope-tabs/main.lua
+++ b/lua/telescope/_extensions/telescope-tabs/main.lua
@@ -43,11 +43,11 @@ local M = {
 }
 
 local default_conf = {
-	entry_formatter = function(tab_id, buffer_ids, file_names, file_paths)
+	entry_formatter = function(tab_id, buffer_ids, file_names, file_paths, is_current)
 		local entry_string = table.concat(file_names, ', ')
 		return string.format('%d: %s', tab_id, entry_string)
 	end,
-	entry_ordinal = function(tab_id, buffer_ids, file_names, file_paths)
+	entry_ordinal = function(tab_id, buffer_ids, file_names, file_paths, is_current)
 		return table.concat(file_names, ' ')
 	end,
 	show_preview = true,
@@ -102,7 +102,7 @@ M.list_tabs = function(opts)
 		if is_current then
 			current_tab.index = index
 		end
-		table.insert(res, { file_names, file_paths, file_ids, window_ids, tid })
+		table.insert(res, { file_names, file_paths, file_ids, window_ids, tid, is_current })
 	end
 	pickers
 		.new(opts, {
@@ -110,8 +110,8 @@ M.list_tabs = function(opts)
 			finder = finders.new_table {
 				results = res,
 				entry_maker = function(entry)
-					local entry_string = opts.entry_formatter(entry[5], entry[3], entry[1], entry[2])
-					local ordinal_string = opts.entry_ordinal(entry[5], entry[3], entry[1], entry[2])
+					local entry_string = opts.entry_formatter(entry[5], entry[3], entry[1], entry[2], entry[6])
+					local ordinal_string = opts.entry_ordinal(entry[5], entry[3], entry[1], entry[2], entry[6])
 					return {
 						value = entry,
 						path = entry[2][1],


### PR DESCRIPTION
Hi, I have a small behavior change proposal: set the initial selection to "current tab".

For example, when user is at the 4th tab, and start the picker with `list_tabs`, let the 4th result be selected initially.

![Pre-select tab4](https://user-images.githubusercontent.com/156608/212443636-880fae88-b240-4417-952c-a770161501b1.png)

This has benefit that user can see the current position, and navigate to relative "next" or "previous" tabs quickly.

---

Also, since the "current tab" is detected, I believe it is good to add a `is_current` argument to `entry_formatter` and `entry_ordinal`.

For example I can use `is_current` to customize my result to show `-` for current tab.