### PR TITLE
fix: ignore floating windows to avoid empty filenames

### DIFF
--- a/lua/telescope/_extensions/telescope-tabs/main.lua
+++ b/lua/telescope/_extensions/telescope-tabs/main.lua
@@ -91,13 +91,16 @@ M.list_tabs = function(opts)
 		local window_ids = {}
 		local is_current = current_tab.number == vim.api.nvim_tabpage_get_number(tid)
 		for _, wid in ipairs(vim.api.nvim_tabpage_list_wins(tid)) do
-			local bid = vim.api.nvim_win_get_buf(wid)
-			local path = vim.api.nvim_buf_get_name(bid)
-			local file_name = vim.fn.fnamemodify(path, ':t')
-			table.insert(file_names, file_name)
-			table.insert(file_paths, path)
-			table.insert(file_ids, bid)
-			table.insert(window_ids, wid)
+			-- Only consider the normal windows and ignore the floating windows
+			if vim.api.nvim_win_get_config(wid).relative == "" then
+				local bid = vim.api.nvim_win_get_buf(wid)
+				local path = vim.api.nvim_buf_get_name(bid)
+				local file_name = vim.fn.fnamemodify(path, ':t')
+				table.insert(file_names, file_name)
+				table.insert(file_paths, path)
+				table.insert(file_ids, bid)
+				table.insert(window_ids, wid)
+			end
 		end
 		if is_current then
 			current_tab.index = index


### PR DESCRIPTION
Floating windows (e.g., the scrollbar, the context window from nvim-treesitter-context) should be ignored to avoid the empty  file names shown in the entry.

<img width="627" alt="before" src="https://github.com/LukasPietzschmann/telescope-tabs/assets/11582667/f932bebe-f40a-4803-8d84-004105c02cf2">

After this PR:

<img width="672" alt="after" src="https://github.com/LukasPietzschmann/telescope-tabs/assets/11582667/ee8fe822-cd3c-4d8e-bafb-b398cc6fb060">

Thank you. 