### PR TITLE
not using anonymous function for action map

### DIFF
--- a/lua/telescope/_extensions/telescope-tabs/main.lua
+++ b/lua/telescope/_extensions/telescope-tabs/main.lua
@@ -130,12 +130,8 @@ M.list_tabs = function(opts)
 					local selection = action_state.get_selected_entry()
 					vim.api.nvim_set_current_tabpage(selection.value[5])
 				end)
-				map('i', opts.close_tab_shortcut_i, function()
-					close_tab(prompt_bufnr)
-				end)
-				map('n', opts.close_tab_shortcut_n, function()
-					close_tab(prompt_bufnr)
-				end)
+				map('i', opts.close_tab_shortcut_i, close_tab)
+				map('n', opts.close_tab_shortcut_n, close_tab)
 				return true
 			end,
 			previewer = opts.show_preview and conf.file_previewer {} or nil,


### PR DESCRIPTION
by passing anonymous function which-key cant show helpful message what the key shortcut does

as telescope by default passes current buffer number to the action there is no need to wrap that param in a partial function

fixes https://github.com/LukasPietzschmann/telescope-tabs/issues/17