### PR TITLE
add option for providing sort function

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ end,
 ```
 To alter this behaviour, just assign your own function.
 
+### sort_function
+This predicate function is used to sort the tabs display order. The default is `nil`
+Example:
+```lua
+sort_function = function(tab_id_a, buffer_ids_a, file_names_a, file_paths_a, is_current_a,
+						tab_id_b, buffer_ids_b, file_names_b, file_paths_b, is_current_b)
+	-- Move the current tab to the top of the list.
+	return is_current_b
+end
+```
+
 ### entry_ordinal
 This changes what queries a tab matches. The following function is used by default:
 ```lua

--- a/doc/telescope-tabs.txt
+++ b/doc/telescope-tabs.txt
@@ -43,6 +43,27 @@ require'telescope-tabs'.setup {
         return string.format('%d: %s%s', tab_id, entry_string, is_current and ' <' or '')
     end,
 
+    -- This predicate function is used to sort the tabs display order.
+    -- By default, tabs are not sorted.
+    -- tab_id_a, tab_id_b: id of the tab. This id can be passed to neovims api in order
+    --         to get information about the tab.
+    -- buffer_ids_a, buffer_ids_b: A list of ids for every buffer opened in the tab. Those
+    --             ids can be passed to neovims api in order to get
+    --             information about the buffer.
+    -- file_names_a, file_names_b: A list of names (strings) for every buffer opened in the
+    --             tab.
+    -- file_paths_a, file_paths_b: A list of paths (strings) for every buffer opened in the
+    --             tab.
+    -- is_current_a, is_current_b: Boolean value, true if it is the current tab.
+    --
+    -- buffer_ids, file_names and file_paths contain their information in
+    -- the same order. So buffer_ids[1], file_names[1] and file_paths[1]
+    -- refer to the same buffer.
+    sort_function = function(tab_id_a, buffer_ids_a, file_names_a, file_paths_a, is_current_a, 
+                          tab_id_b, buffer_ids_b, file_names_b, file_paths_b, is_current_b)
+        return tab_id_a > tab_id_b
+    end
+
     -- This function is used to convert a tab to a string that is then
     -- used determine if a tab matches a given search query.
     -- tab_id: id of the tab. This id can be passed to neovims api in order

--- a/lua/telescope/_extensions/telescope-tabs/main.lua
+++ b/lua/telescope/_extensions/telescope-tabs/main.lua
@@ -43,6 +43,7 @@ local M = {
 }
 
 local default_conf = {
+  sort_function = nil,
 	entry_formatter = function(tab_id, buffer_ids, file_names, file_paths, is_current)
 		local entry_string = table.concat(file_names, ', ')
 		return string.format('%d: %s%s', tab_id, entry_string, is_current and ' <' or '')
@@ -111,6 +112,11 @@ M.list_tabs = function(opts)
 		end
 		table.insert(res, { file_names, file_paths, file_ids, window_ids, tid, is_current })
 	end
+  if opts.sort_function ~= nil then
+    table.sort(res, function(a, b)
+      return opts.sort_function(a[5], a[3], a[1], a[2], a[6], b[5], b[3], b[1], b[2], b[6])
+    end)
+  end
 	pickers
 		.new(opts, {
 			prompt_title = 'Tabs',


### PR DESCRIPTION
Solution from what I mentioned in the issue
Off by default, function with 10 args might be too much, but it follows the conjecture
I can add the docs
example:
``` lua
sort_function = function(tab_id_a, buffer_ids_a, file_names_a, file_paths_a, is_current_a, 
                          tab_id_b, buffer_ids_b, file_names_b, file_paths_b, is_current_b)
  if is_current_b then
    return true
  end
  return false
end
```